### PR TITLE
Fix: Correct CORS configuration for Vercel deployment

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ const app=express();
 app.use(cors({
      origin: [
     // "https://yatra-quest-website-development.vercel.app",
-    "https://yatra-quest-website.vercel.app/",
+    "https://yatra-quest-website.vercel.app",
     "http://localhost:5173",
     "http://localhost:5175"
   ],


### PR DESCRIPTION
The backend was configured to allow CORS requests from "https://yatra-quest-website.vercel.app/", with a trailing slash. However, browsers send the Origin header as "https://yatra-quest-website.vercel.app" (without the trailing slash). This mismatch caused the 'Access-Control-Allow-Origin' header to not be sent, blocking your frontend API requests.

This commit removes the trailing slash from the Vercel URL in the CORS origin list in `index.js` to resolve the issue.